### PR TITLE
(MCOP-538) Added display of avg values to the puppet summary report

### DIFF
--- a/application/puppet.rb
+++ b/application/puppet.rb
@@ -183,6 +183,9 @@ END_OF_USAGE
 
     min = values.min
     max = values.max
+    total = values.inject(:+)
+    len = values.length
+    avg = total.to_f / len
 
     bucket_size = ((max - min) / Float(bucket_count)) + 1
 
@@ -193,7 +196,7 @@ END_OF_USAGE
       end
     end
 
-    "%s  min: %-6s max: %-6s" % [spark(buckets), shorten_number(min), shorten_number(max)]
+    "%s  min: %-6s avg: %-6s max: %-6s" % [spark(buckets), shorten_number(min), shorten_number(avg), shorten_number(max)]
   end
 
   def client

--- a/spec/application/puppet_spec.rb
+++ b/spec/application/puppet_spec.rb
@@ -137,7 +137,7 @@ module MCollective
           end
 
           @app.expects(:spark).with([2, 2, 2, 2, 2, 2, 0, 0, 0, 0, 0]).returns("rspec")
-          @app.sparkline_for_field(results, :rspec, 11).should == "rspec  min: 10.0   max: 21.0  "
+          @app.sparkline_for_field(results, :rspec, 11).should == "rspec  min: 10.0   avg: 15.5   max: 21.0  "
         end
 
         it 'should return an empty string with bad data to extract from' do


### PR DESCRIPTION
Relates to issue reported:

https://tickets.puppetlabs.com/browse/MCO-547