### PR TITLE
MCOP-445 fix travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ rvm:
   - 1.9.3
 env:
   matrix:
-    - MCOLLECTIVE_GEM_VERSION ="~> 2.2.0"
-    - MCOLLECTIVE_GEM_VERSION ="~> 2.3.0"
-    - MCOLLECTIVE_GEM_VERSION ="~> 2.4.0"
+    - MCOLLECTIVE_GEM_VERSION="~> 2.5.0"
+    - MCOLLECTIVE_GEM_VERSION="~> 2.6.0"
+    - MCOLLECTIVE_GEM_VERSION="~> 2.7.0"
 notifications:
   email: false


### PR DESCRIPTION
The travis matrix was copied from a bad example, and so the
MCOLLECTIVE_GEM_VERSION was not correctly being assigned a version.
Here we correct this with an updated matrix.