### PR TITLE
MCOP-496 Use the puppet 3 manager for puppet 4

### DIFF
--- a/spec/util/puppet_agent_mgr_spec.rb
+++ b/spec/util/puppet_agent_mgr_spec.rb
@@ -36,6 +36,12 @@ module MCollective::Util
           PuppetAgentMgr.manager(nil, "puppet", nil, true)
         end
 
+        it "should use the 3 manager for puppet 4" do
+          Puppet.expects(:version).returns("4.0.0")
+          PuppetAgentMgr::MgrV3.expects(:new)
+          PuppetAgentMgr.manager(nil, "puppet", nil, true)
+        end
+
         it "should pass the supplied config file to the manager" do
           Puppet.expects(:version).returns("3.0.0")
           PuppetAgentMgr::MgrV3.expects(:new).with(

--- a/util/puppet_agent_mgr.rb
+++ b/util/puppet_agent_mgr.rb
@@ -51,7 +51,7 @@ module MCollective
               when "2"
                 raise "Window is not supported yet" if MCollective::Util.windows?
                 return MgrV2.new(configfile, service_name, testing)
-              when "3"
+              when "3", "4"
                 if MCollective::Util.windows?
                   return MgrWindows.new(configfile, service_name, testing)
                 else


### PR DESCRIPTION
Puppet 4's behaviour around lockfiles and signals is consistent
with that of puppet 3, so it's safe to use the v3 manager here.
