### PR TITLE
MCOP-521 Use win32/process to ensure powershell gets a console

### DIFF
--- a/agent/puppet.rb
+++ b/agent/puppet.rb
@@ -18,11 +18,13 @@ module MCollective
 
       def run(command, options)
         if MCollective::Util.windows?
+          require 'win32/process'
           # If creating the process doesn't outright fail, assume everything
           # was okay. The caller wants to know our exit code, so we'll just use
           # 0 or 1.
           begin
-            ::Process.spawn(command, :new_pgroup => true)
+            ::Process.create(:command_line => command,
+                             :creation_flags => ::Process::CREATE_NEW_CONSOLE)
             0
           rescue ::Process::Error => e
             1


### PR DESCRIPTION
As noted in https://github.com/puppetlabs/puppet/commit/61669e Powershell needs
to be running in its own console for the powershell exec provider to function
correctly.

Here we partially revert commit b79b2b1cf886e370f988dd1f7c7f623652e25cc9, using
::Process::CREATE_NEW_CONSOLE after puppet rather than the previous
::Process::CREATE_NO_WINDOW creation flag.