### PR TITLE
(MCOP-526) Pass splay arguments if signal_daemon is false

### DIFF
--- a/agent/puppet.rb
+++ b/agent/puppet.rb
@@ -205,8 +205,9 @@ module MCollective
         args[:ignoreschedules] = request[:ignoreschedules] if request[:ignoreschedules]
         args[:signal_daemon] = false if MCollective::Util.windows?
 
-        # we can only pass splay arguments if the daemon isn't running :(
-        unless @puppet_agent.status[:daemon_present]
+        # we can only pass splay arguments if the daemon isn't running or we're
+        # not going to signal it :(
+        if !@puppet_agent.status[:daemon_present] || !args[:signal_daemon]
           if request[:force] == true
             # forcing implies --no-splay
             args[:splay] = false


### PR DESCRIPTION
Here we change the logic in #runonce slightly to also set the splay
arguments if the daemon is present but we're not going to signal it.