### PR TITLE
Enable splay/force options when using puppet in daemon mode, without signal_daemon set

### DIFF
--- a/agent/puppet.rb
+++ b/agent/puppet.rb
@@ -205,8 +205,9 @@ module MCollective
         args[:ignoreschedules] = request[:ignoreschedules] if request[:ignoreschedules]
         args[:signal_daemon] = false if MCollective::Util.windows?
 
-        # we can only pass splay arguments if the daemon isn't running :(
-        unless @puppet_agent.status[:daemon_present]
+        # we can only pass splay arguments if the daemon isn't in signal mode :(
+        signal_daemon = Util.str_to_bool(@config.pluginconf.fetch("puppet.signal_daemon","true")) 
+        unless @puppet_agent.status[:daemon_present] && signal_daemon
           if request[:force] == true
             # forcing implies --no-splay
             args[:splay] = false


### PR DESCRIPTION
When using puppet in daemon mode, you can't give additional arguments
using signal_daemon to trigger a run.  Here we allow mcollective
to pass a splay argument when puppet is running in daemon mode.