### PR TITLE
Update documentation for actionpolicy dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ And you can then allow the manager user to disable and enable nodes using the
 Together this allows you to ensure that you both have a maintenance window and a
 period where Puppet will not start services again without your knowledge
 
-Note: The runall action is implemented as a runonce command.  When setting up Actionpolicy rules, be sure to include a runonce action permission.
+Note: The runall action is implemented in terms of the runonce action.  When setting up Actionpolicy rules, be sure to include a runonce action permission.
 
 ### Managing individual resources using the RAL
 

--- a/README.md
+++ b/README.md
@@ -321,6 +321,8 @@ And you can then allow the manager user to disable and enable nodes using the
 Together this allows you to ensure that you both have a maintenance window and a
 period where Puppet will not start services again without your knowledge
 
+Note: The runall action is implemented as a runonce command.  When setting up Actionpolicy rules, be sure to include a runonce action permission.
+
 ### Managing individual resources using the RAL
 
 Puppet is built on resource types and providers for those types, an instance of


### PR DESCRIPTION
After several hours wondering what was going on, I discovered that the runall command is implemented as a runonce command.  If you were to create a rule permitting runall without runonce, the rule will fail in an unobvious way.