### PR TITLE
MCO-759 MCO Puppet agent missing use_cached_catalog option

### DIFF
--- a/agent/puppet.ddl
+++ b/agent/puppet.ddl
@@ -258,6 +258,12 @@ action "runonce", :description => "Invoke a single Puppet run" do
           :optional    => true,
           :maxlength   => 50
 
+    input :use_cached_catalog,
+          :prompt      => "Use Cached Catalog",
+          :description => "Determine if to use the cached catalog or not",
+          :type        => :boolean,
+          :optional    => true
+
     output :summary,
            :description => "Summary of command run",
            :display_as  => "Summary",

--- a/agent/puppet.rb
+++ b/agent/puppet.rb
@@ -204,6 +204,7 @@ module MCollective
         args[:tags] = request[:tags].split(",").map{|t| t.strip} if request[:tags]
         args[:ignoreschedules] = request[:ignoreschedules] if request[:ignoreschedules]
         args[:signal_daemon] = false if MCollective::Util.windows?
+        args[:use_cached_catalog] = request[:use_cached_catalog] if request.include?(:use_cached_catalog)
 
         # we can only pass splay arguments if the daemon isn't in signal mode :(
         signal_daemon = Util.str_to_bool(@config.pluginconf.fetch("puppet.signal_daemon","true")) 

--- a/application/puppet.rb
+++ b/application/puppet.rb
@@ -70,6 +70,16 @@ END_OF_USAGE
          :description => "Maximum splay time for this run if splay is set",
          :type        => Integer
 
+  option :use_cached_catalog,
+         :arguments   => ["--use_cached_catalog"],
+         :description => "Use cached catalog for this run",
+         :type        => :bool
+
+  option :no_use_cached_catalog,
+         :arguments   => ["--no-use_cached_catalog"],
+         :description => "Do not use cached catalog for this run",
+         :type        => :bool
+
   option :ignoreschedules,
          :arguments   => ["--ignoreschedules"],
          :description => "Disable schedule processing",
@@ -125,6 +135,7 @@ END_OF_USAGE
 
     configuration[:noop] = false if configuration.include?(:no_noop)
     configuration[:splay] = false if configuration.include?(:no_splay)
+    configuration[:use_cached_catalog] = false if configuration.include?(:no_use_cached_catalog)
   end
 
   def raise_message(message, *args)
@@ -232,7 +243,7 @@ END_OF_USAGE
   def runonce_arguments
     arguments = {}
 
-    [:force, :server, :noop, :environment, :splay, :splaylimit, :ignoreschedules].each do |arg|
+    [:use_cached_catalog, :force, :server, :noop, :environment, :splay, :splaylimit, :ignoreschedules].each do |arg|
       arguments[arg] = configuration[arg] if configuration.include?(arg)
     end
 

--- a/spec/agent/puppet_agent_spec.rb
+++ b/spec/agent/puppet_agent_spec.rb
@@ -466,6 +466,26 @@ describe "puppet agent" do
       result.should be_successful
     end
 
+    it "should support no-use_cached_catalog" do
+      @manager.expects(:runonce!).with(
+        {:options_only => true,
+         :splay => true,
+         :use_cached_catalog => false,
+         :splaylimit => 30}).returns([:signal_running_daemon, []])
+      result = @agent.call(:runonce, :use_cached_catalog => false)
+      result.should be_successful
+    end
+
+    it "should support use_Cached_catalog" do
+      @manager.expects(:runonce!).with(
+        {:options_only => true,
+         :splay => true,
+         :use_cached_catalog => true,
+         :splaylimit => 30}).returns([:signal_running_daemon, []])
+      result = @agent.call(:runonce, :use_cached_catalog => true)
+      result.should be_successful
+    end
+
     it "should support setting the environment" do
       @manager.expects(:runonce!).with(
         {:options_only => true,

--- a/spec/application/puppet_spec.rb
+++ b/spec/application/puppet_spec.rb
@@ -174,9 +174,10 @@ module MCollective
           @app.configuration[:splay] = true
           @app.configuration[:splaylimit] = 60
           @app.configuration[:tag] = ["one", "two"]
+          @app.configuration[:use_cached_catalog] = false
           @app.configuration[:ignoreschedules] = true
 
-          @app.runonce_arguments.should == {:splaylimit=>60, :force=>true, :environment=>"rspec", :noop=>true, :server=>"rspec:123", :tags=>"one,two", :splay=>true, :ignoreschedules=>true}
+          @app.runonce_arguments.should == {:splaylimit=>60, :force=>true, :environment=>"rspec", :noop=>true, :server=>"rspec:123", :tags=>"one,two", :splay=>true, :use_cached_catalog=>false, :ignoreschedules=>true}
         end
       end
 
@@ -251,6 +252,7 @@ module MCollective
           @app.configuration[:splay] = true
           @app.configuration[:splaylimit] = 60
           @app.configuration[:tag] = ["one", "two"]
+          @app.configuration[:use_cached_catalog] = false
           @app.configuration[:ignoreschedules] = true
 
           @app.client.expects(:runonce).with(:force => true,
@@ -259,6 +261,7 @@ module MCollective
                                              :environment => "rspec",
                                              :splay => true,
                                              :splaylimit => 60,
+                                             :use_cached_catalog => false,
                                              :ignoreschedules => true,
                                              :tags => "one,two").returns("result")
           @app.expects(:halt)

--- a/util/puppet_agent_mgr.rb
+++ b/util/puppet_agent_mgr.rb
@@ -203,7 +203,7 @@ module MCollective
       # validates arguments and returns the CL options to execute puppet
       def create_common_puppet_cli(noop=nil, tags=[], environment=nil,
                                    server=nil, splay=nil, splaylimit=nil,
-                                   ignoreschedules=nil)
+                                   ignoreschedules=nil, use_cached_catalog=nil)
         opts = []
         tags = [tags].flatten.compact
 
@@ -237,6 +237,8 @@ module MCollective
         opts << "--server %s" % hostname if hostname
         opts << "--masterport %s" % port if port
         opts << "--ignoreschedules" if ignoreschedules
+        opts << "--use_cached_catalog" if use_cached_catalog == true
+        opts << "--no-use_cached_catalog" if use_cached_catalog == false
         opts
       end
 
@@ -273,7 +275,7 @@ module MCollective
       def runonce!(options={})
         valid_options = [:noop, :signal_daemon, :foreground_run, :tags,
                          :environment, :server, :splay, :splaylimit,
-                         :options_only, :ignoreschedules]
+                         :options_only, :ignoreschedules, :use_cached_catalog]
 
         options.keys.each do |opt|
           unless valid_options.include?(opt)
@@ -298,11 +300,12 @@ module MCollective
         environment     = options.fetch(:environment, nil)
         server          = options.fetch(:server, nil)
         ignoreschedules = options.fetch(:ignoreschedules, nil)
+        use_cached_catalog = options.fetch(:use_cached_catalog, nil)
         tags            = [ options[:tags] ].flatten.compact
 
         clioptions = create_common_puppet_cli(noop, tags, environment,
                                               server, splay, splaylimit,
-                                              ignoreschedules)
+                                              ignoreschedules, use_cached_catalog)
 
         if idling? && signal_daemon && !clioptions.empty?
           raise "Cannot specify any custom puppet options " \


### PR DESCRIPTION
The improvement allows user to trigger full enforcement Puppet runs when
Puppet is configured with `use_cached_catalog` in the Puppet config file.
The improvement can also trigger a cached catalog run if desired.