### PR TITLE
(MCOP-537) - runhosts should not block on a single busy node.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 source 'https://rubygems.org'
 
 group :test do
-  gem 'rake'
+  gem 'rake', '~> 10.4'
   gem 'rspec', '~> 2.11.0'
   gem 'mocha', '~> 0.10.0'
   gem 'mcollective-test'

--- a/README.md
+++ b/README.md
@@ -321,6 +321,8 @@ And you can then allow the manager user to disable and enable nodes using the
 Together this allows you to ensure that you both have a maintenance window and a
 period where Puppet will not start services again without your knowledge
 
+Note: The runall action is implemented in terms of the runonce action.  When setting up Actionpolicy rules, be sure to include a runonce action permission.
+
 ### Managing individual resources using the RAL
 
 Puppet is built on resource types and providers for those types, an instance of

--- a/agent/puppet.ddl
+++ b/agent/puppet.ddl
@@ -258,6 +258,12 @@ action "runonce", :description => "Invoke a single Puppet run" do
           :optional    => true,
           :maxlength   => 50
 
+    input :use_cached_catalog,
+          :prompt      => "Use Cached Catalog",
+          :description => "Determine if to use the cached catalog or not",
+          :type        => :boolean,
+          :optional    => true
+
     output :summary,
            :description => "Summary of command run",
            :display_as  => "Summary",

--- a/agent/puppet.rb
+++ b/agent/puppet.rb
@@ -204,6 +204,7 @@ module MCollective
         args[:tags] = request[:tags].split(",").map{|t| t.strip} if request[:tags]
         args[:ignoreschedules] = request[:ignoreschedules] if request[:ignoreschedules]
         args[:signal_daemon] = false if MCollective::Util.windows?
+        args[:use_cached_catalog] = request[:use_cached_catalog] if request.include?(:use_cached_catalog)
 
         # we can only pass splay arguments if the daemon isn't in signal mode :(
         signal_daemon = Util.str_to_bool(@config.pluginconf.fetch("puppet.signal_daemon","true")) 

--- a/application/puppet.rb
+++ b/application/puppet.rb
@@ -70,6 +70,16 @@ END_OF_USAGE
          :description => "Maximum splay time for this run if splay is set",
          :type        => Integer
 
+  option :use_cached_catalog,
+         :arguments   => ["--use_cached_catalog"],
+         :description => "Use cached catalog for this run",
+         :type        => :bool
+
+  option :no_use_cached_catalog,
+         :arguments   => ["--no-use_cached_catalog"],
+         :description => "Do not use cached catalog for this run",
+         :type        => :bool
+
   option :ignoreschedules,
          :arguments   => ["--ignoreschedules"],
          :description => "Disable schedule processing",
@@ -125,6 +135,7 @@ END_OF_USAGE
 
     configuration[:noop] = false if configuration.include?(:no_noop)
     configuration[:splay] = false if configuration.include?(:no_splay)
+    configuration[:use_cached_catalog] = false if configuration.include?(:no_use_cached_catalog)
   end
 
   def raise_message(message, *args)
@@ -232,7 +243,7 @@ END_OF_USAGE
   def runonce_arguments
     arguments = {}
 
-    [:force, :server, :noop, :environment, :splay, :splaylimit, :ignoreschedules].each do |arg|
+    [:use_cached_catalog, :force, :server, :noop, :environment, :splay, :splaylimit, :ignoreschedules].each do |arg|
       arguments[arg] = configuration[arg] if configuration.include?(arg)
     end
 

--- a/spec/agent/puppet_agent_spec.rb
+++ b/spec/agent/puppet_agent_spec.rb
@@ -466,6 +466,26 @@ describe "puppet agent" do
       result.should be_successful
     end
 
+    it "should support no-use_cached_catalog" do
+      @manager.expects(:runonce!).with(
+        {:options_only => true,
+         :splay => true,
+         :use_cached_catalog => false,
+         :splaylimit => 30}).returns([:signal_running_daemon, []])
+      result = @agent.call(:runonce, :use_cached_catalog => false)
+      result.should be_successful
+    end
+
+    it "should support use_Cached_catalog" do
+      @manager.expects(:runonce!).with(
+        {:options_only => true,
+         :splay => true,
+         :use_cached_catalog => true,
+         :splaylimit => 30}).returns([:signal_running_daemon, []])
+      result = @agent.call(:runonce, :use_cached_catalog => true)
+      result.should be_successful
+    end
+
     it "should support setting the environment" do
       @manager.expects(:runonce!).with(
         {:options_only => true,

--- a/spec/application/puppet_spec.rb
+++ b/spec/application/puppet_spec.rb
@@ -174,9 +174,10 @@ module MCollective
           @app.configuration[:splay] = true
           @app.configuration[:splaylimit] = 60
           @app.configuration[:tag] = ["one", "two"]
+          @app.configuration[:use_cached_catalog] = false
           @app.configuration[:ignoreschedules] = true
 
-          @app.runonce_arguments.should == {:splaylimit=>60, :force=>true, :environment=>"rspec", :noop=>true, :server=>"rspec:123", :tags=>"one,two", :splay=>true, :ignoreschedules=>true}
+          @app.runonce_arguments.should == {:splaylimit=>60, :force=>true, :environment=>"rspec", :noop=>true, :server=>"rspec:123", :tags=>"one,two", :splay=>true, :use_cached_catalog=>false, :ignoreschedules=>true}
         end
       end
 
@@ -251,6 +252,7 @@ module MCollective
           @app.configuration[:splay] = true
           @app.configuration[:splaylimit] = 60
           @app.configuration[:tag] = ["one", "two"]
+          @app.configuration[:use_cached_catalog] = false
           @app.configuration[:ignoreschedules] = true
 
           @app.client.expects(:runonce).with(:force => true,
@@ -259,6 +261,7 @@ module MCollective
                                              :environment => "rspec",
                                              :splay => true,
                                              :splaylimit => 60,
+                                             :use_cached_catalog => false,
                                              :ignoreschedules => true,
                                              :tags => "one,two").returns("result")
           @app.expects(:halt)

--- a/util/puppet_agent_mgr.rb
+++ b/util/puppet_agent_mgr.rb
@@ -203,7 +203,7 @@ module MCollective
       # validates arguments and returns the CL options to execute puppet
       def create_common_puppet_cli(noop=nil, tags=[], environment=nil,
                                    server=nil, splay=nil, splaylimit=nil,
-                                   ignoreschedules=nil)
+                                   ignoreschedules=nil, use_cached_catalog=nil)
         opts = []
         tags = [tags].flatten.compact
 
@@ -237,6 +237,8 @@ module MCollective
         opts << "--server %s" % hostname if hostname
         opts << "--masterport %s" % port if port
         opts << "--ignoreschedules" if ignoreschedules
+        opts << "--use_cached_catalog" if use_cached_catalog == true
+        opts << "--no-use_cached_catalog" if use_cached_catalog == false
         opts
       end
 
@@ -273,7 +275,7 @@ module MCollective
       def runonce!(options={})
         valid_options = [:noop, :signal_daemon, :foreground_run, :tags,
                          :environment, :server, :splay, :splaylimit,
-                         :options_only, :ignoreschedules]
+                         :options_only, :ignoreschedules, :use_cached_catalog]
 
         options.keys.each do |opt|
           unless valid_options.include?(opt)
@@ -298,11 +300,12 @@ module MCollective
         environment     = options.fetch(:environment, nil)
         server          = options.fetch(:server, nil)
         ignoreschedules = options.fetch(:ignoreschedules, nil)
+        use_cached_catalog = options.fetch(:use_cached_catalog, nil)
         tags            = [ options[:tags] ].flatten.compact
 
         clioptions = create_common_puppet_cli(noop, tags, environment,
                                               server, splay, splaylimit,
-                                              ignoreschedules)
+                                              ignoreschedules, use_cached_catalog)
 
         if idling? && signal_daemon && !clioptions.empty?
           raise "Cannot specify any custom puppet options " \

--- a/util/puppetrunner.rb
+++ b/util/puppetrunner.rb
@@ -67,23 +67,31 @@ module MCollective
         running = find_applying_nodes(host_list)
 
         while !host_list.empty?
-          # Check if we have room in the running bucket
-          if running.size < @concurrency
-            # we have room for another running host
-            host = host_list.pop
+          # clone list so we can safely remove items
+          working_list = host_list.clone
+
+          working_list.each do |host|
+            if running.size >= @concurrency
+              # we do not have room for another running host
+              break
+            end
             # check if host is already in a running state
-            if !running.select{ |running_host| running_host[:name] == host }.empty?
-              # already in a running state, push it back onto the end of the queue
-              Log.debug("#{host} is already being tracked, requeuing")
-              host_list.push(host)
-            else
-              # kick the host, put it in the running bucket
+            Log.debug("Checking #{host}")
+            Log.debug(" -- running: %d, concurrency: %d" % [running.size, @concurrency])
+            if running.select{ |running_host| running_host[:name] == host }.empty?
+              # host is not running - kick it, put it in the running bucket
+              Log.debug("Triggering #{host}")
               initiated_at = runhost(host)
               running << make_status(host, initiated_at)
+              host_list.delete(host)
               next
+            else
+              # already in a running state, leave it for now
+              Log.debug("#{host} is already being tracked, skipping it")
             end
           end
 
+          Log.debug("Sleeping")
           # wait a second to give some time for something to happen
           sleep 1
           # update our view of the network


### PR DESCRIPTION
This change addresses both of the problems mentioned in the description of MCOP-537.

This is my first pull request for the MCollective Plugins ; please let me know if there is some other procedure that I need to follow.

Thanks!