### PR TITLE
(maint) Fix TravisCI, Ruby 1.8.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 source 'https://rubygems.org'
 
 group :test do
-  gem 'rake'
+  gem 'rake', '~> 10.4'
   gem 'rspec', '~> 2.11.0'
   gem 'mocha', '~> 0.10.0'
   gem 'mcollective-test'


### PR DESCRIPTION
Rake 11 doesn't work with Ruby 1.8.7, which we still test against. Pin
to Rake 10.