### PR TITLE
(MCOP-580) Improve last_run_summary logs output

### DIFF
--- a/agent/puppet.ddl
+++ b/agent/puppet.ddl
@@ -83,9 +83,9 @@ end
 action "last_run_summary", :description => "Get the summary of the last Puppet run" do
     display :always
 
-    input  :parse_log,
+    input  :logs,
            :description => "Whether or not to parse the logs from last_run_report.yaml",
-           :prompt      => "Parse log from last_run_report.yaml?",
+           :prompt      => "Parse log from last_run_report.yaml",
            :optional    => true,
            :type        => :boolean,
            :default     => false

--- a/agent/puppet.rb
+++ b/agent/puppet.rb
@@ -87,7 +87,7 @@ module MCollective
       action "last_run_summary" do
         summary = @puppet_agent.load_summary
 
-        if request[:parse_log]
+        if request[:logs]
           reply[:logs] = @puppet_agent.last_run_logs
         else
           reply[:logs] = {}

--- a/spec/agent/puppet_agent_spec.rb
+++ b/spec/agent/puppet_agent_spec.rb
@@ -366,7 +366,7 @@ describe "puppet agent" do
       result[:data][:type_distribution].should == {"File" => 1, "Exec" => 2}
     end
 
-    context 'parse_log' do
+    context 'logs' do
       before :each do
         @manager.stubs(:load_summary).returns({})
       end
@@ -381,7 +381,7 @@ describe "puppet agent" do
       context 'true' do
         it 'should call on last_run_logs' do
           @manager.expects(:last_run_logs).once
-          @agent.call(:last_run_summary, :parse_log => true)
+          @agent.call(:last_run_summary, :logs => true)
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,7 @@ module Puppet
   end
   class Util;end
   class Util::Log
-    attr_reader :level, :message
+    attr_reader :level, :message, :time, :source
     @loglevel = 2
     @levels = [:debug,:info,:notice,:warning,:err,:alert,:emerg,:crit]
     def self.level

--- a/spec/util/puppet_agent_mgr_spec.rb
+++ b/spec/util/puppet_agent_mgr_spec.rb
@@ -288,7 +288,7 @@ module MCollective::Util
         it "should return a default structure when no file is found" do
           Puppet.expects(:[]).with(:lastrunreport).returns("lastrunreport")
 
-          @manager.last_run_logs.should == {}
+          expect(@manager.last_run_logs).to eq([])
         end
 
         it "should return log results if the file is found" do
@@ -297,15 +297,16 @@ module MCollective::Util
                                                 "last_run_report.yaml"))
           Puppet.expects(:[]).with(:lastrunreport).returns(yamlfile).times(2..3)
 
-          @manager.last_run_logs.should \
-            == {"info"    => ["Info level message"],
-                "err"     => ["Err level message"],
-                "debug"   => ["Debug level message"],
-                "warning" => ["Warning level message"],
-                "crit"    => ["Crit level message"],
-                "alert"   => ["Alert level message"],
-                "emerg"   => ["Emerg level message"],
-                "notice"  => ["Notice level message"]}
+          expect(@manager.last_run_logs).to eq([
+            {"time_utc"=>1378216841, "time"=>1378216841, "level"=>"notice", "source"=>"Puppet", "msg"=>"Notice level message"},
+            {"time_utc"=>1378216841, "time"=>1378216841, "level"=>"err", "source"=>"Puppet", "msg"=>"Err level message"},
+            {"time_utc"=>1378216841, "time"=>1378216841, "level"=>"warning", "source"=>"Puppet", "msg"=>"Warning level message"},
+            {"time_utc"=>1378216841, "time"=>1378216841, "level"=>"debug", "source"=>"Puppet", "msg"=>"Debug level message"},
+            {"time_utc"=>1378216841, "time"=>1378216841, "level"=>"crit", "source"=>"Puppet", "msg"=>"Crit level message"},
+            {"time_utc"=>1378216841, "time"=>1378216841, "level"=>"alert", "source"=>"Puppet", "msg"=>"Alert level message"},
+            {"time_utc"=>1378216841, "time"=>1378216841, "level"=>"info", "source"=>"Puppet", "msg"=>"Info level message"},
+            {"time_utc"=>1378216841, "time"=>1378216841, "level"=>"emerg", "source"=>"Puppet", "msg"=>"Emerg level message"}
+          ])
         end
       end
 
@@ -828,7 +829,7 @@ module MCollective::Util
         it "should return a default structure when no file is found" do
           Puppet.expects(:[]).with(:lastrunreport).returns("lastrunreport")
 
-          @manager.last_run_logs.should == {}
+          expect(@manager.last_run_logs).to eq([])
         end
 
         it "should return log results if the file is found" do
@@ -837,15 +838,16 @@ module MCollective::Util
                                                 "last_run_report.yaml"))
           Puppet.expects(:[]).with(:lastrunreport).returns(yamlfile).times(2..3)
 
-          @manager.last_run_logs.should \
-            == {"info" => ["Info level message"],
-                "err" => ["Err level message"],
-                "debug" => ["Debug level message"],
-                "warning" => ["Warning level message"],
-                "crit" => ["Crit level message"],
-                "alert" => ["Alert level message"],
-                "emerg" => ["Emerg level message"],
-                "notice" => ["Notice level message"]}
+          expect(@manager.last_run_logs).to eq([
+            {"time_utc"=>1378216841, "time"=>1378216841, "level"=>"notice", "source"=>"Puppet", "msg"=>"Notice level message"},
+            {"time_utc"=>1378216841, "time"=>1378216841, "level"=>"err", "source"=>"Puppet", "msg"=>"Err level message"},
+            {"time_utc"=>1378216841, "time"=>1378216841, "level"=>"warning", "source"=>"Puppet", "msg"=>"Warning level message"},
+            {"time_utc"=>1378216841, "time"=>1378216841, "level"=>"debug", "source"=>"Puppet", "msg"=>"Debug level message"},
+            {"time_utc"=>1378216841, "time"=>1378216841, "level"=>"crit", "source"=>"Puppet", "msg"=>"Crit level message"},
+            {"time_utc"=>1378216841, "time"=>1378216841, "level"=>"alert", "source"=>"Puppet", "msg"=>"Alert level message"},
+            {"time_utc"=>1378216841, "time"=>1378216841, "level"=>"info", "source"=>"Puppet", "msg"=>"Info level message"},
+            {"time_utc"=>1378216841, "time"=>1378216841, "level"=>"emerg", "source"=>"Puppet", "msg"=>"Emerg level message"}
+          ])
         end
       end
 

--- a/util/puppet_agent_mgr.rb
+++ b/util/puppet_agent_mgr.rb
@@ -124,18 +124,23 @@ module MCollective
         type_distribution
       end
 
-      # loads the report file and returns log messages grouped by log levels
+      # Reads the last run report and extracts the log lines
+      #
+      # @return [Array<Hash>]
       def last_run_logs
-        logs = {}
-        if File.exists?(Puppet[:lastrunreport])
-          report = YAML.load_file(Puppet[:lastrunreport])
-          levels = Puppet::Util::Log.levels
-          levels.each do |level|
-            logs[level.to_s] = report.logs.select {
-              |r| r.level == level }.map { |r| r.message.chomp }
-          end
+        return [] unless File.exists?(Puppet[:lastrunreport])
+
+        report = YAML.load_file(Puppet[:lastrunreport])
+
+        report.logs.map do |line|
+          {
+            "time_utc" => line.time.utc.to_i,
+            "time" => line.time.to_i,
+            "level" => line.level.to_s,
+            "source" => line.source,
+            "msg" => line.message.chomp
+          }
         end
-        logs
       end
 
       # covert seconds to human readable string


### PR DESCRIPTION
This improves the logs output from last_run_summary by adding details
about the logs such as time, source etc.

The old output was considered largely pointless and we decided to make
a breaking change to improve things.  The old 'parse_log' input is
removed thus forcing code that relied on the old behaviour to fail
with a DDL error rather than later fail in weird ways when the data format
has changed