### PR TITLE
(MCOP-581) do not assume a disabled agent is idle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: ruby
 bundler_args: --without development
 script: "bundle exec rake test SPEC_OPTS='--format documentation'"
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.1.9
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ script: "bundle exec rake test SPEC_OPTS='--format documentation'"
 rvm:
   - 1.8.7
   - 1.9.3
+  - 2.1.9
 env:
   matrix:
     - MCOLLECTIVE_GEM_VERSION="~> 2.5.0"

--- a/spec/util/puppet_agent_mgr/mgr_v2_spec.rb
+++ b/spec/util/puppet_agent_mgr/mgr_v2_spec.rb
@@ -29,13 +29,7 @@ module MCollective::Util
     end
 
     describe "#applying?" do
-      it "should return false when disabled" do
-        @manager.expects(:disabled?).returns(true)
-        @manager.applying?.should == false
-      end
-
       it "should return false when the lock file is absent" do
-        @manager.expects(:disabled?).returns(false)
         File.expects(:exist?).with("puppetdlockfile").returns(false)
         MCollective::Log.expects(:warn).never
         File::Stat.expects(:new).never
@@ -47,7 +41,6 @@ module MCollective::Util
         File::Stat.expects(:new).returns(stat)
         File.expects(:exist?).with("puppetdlockfile").returns(true)
         File.expects(:read).with("puppetdlockfile").returns("1")
-        @manager.expects(:disabled?).returns(false)
         @manager.expects(:has_process_for_pid?).with("1").returns(true)
         @manager.applying?.should == true
       end
@@ -55,7 +48,6 @@ module MCollective::Util
       it "should return false if the lockfile is empty" do
         stat = OpenStruct.new(:size => 0)
         File::Stat.expects(:new).returns(stat)
-        @manager.expects(:disabled?).returns(false)
         File.expects(:exist?).with("puppetdlockfile").returns(true)
         @manager.applying?.should == false
       end
@@ -65,13 +57,12 @@ module MCollective::Util
         File::Stat.expects(:new).returns(stat)
         File.expects(:exist?).with("puppetdlockfile").returns(true)
         File.expects(:read).with("puppetdlockfile").returns("1")
-        @manager.expects(:disabled?).returns(false)
         @manager.expects(:has_process_for_pid?).with("1").returns(false)
         @manager.applying?.should == false
       end
 
       it "should return false on any error" do
-        @manager.expects(:disabled?).raises("fail")
+        @manager.expects(:platform_applying?).raises("fail")
         MCollective::Log.expects(:warn)
         @manager.applying?.should == false
       end

--- a/spec/util/puppet_agent_mgr/mgr_v3_spec.rb
+++ b/spec/util/puppet_agent_mgr/mgr_v3_spec.rb
@@ -29,13 +29,7 @@ module MCollective::Util
     end
 
     describe "#applying?" do
-      it "should return false when disabled" do
-        @manager.expects(:disabled?).returns(true)
-        @manager.applying?.should == false
-      end
-
       it "should return false when the lock file is absent" do
-        @manager.expects(:disabled?).returns(false)
         File.expects(:exist?).with("agent_catalog_run_lockfile").returns(false)
         File::Stat.expects(:new).never
         MCollective::Log.expects(:warn).never
@@ -47,7 +41,6 @@ module MCollective::Util
         File::Stat.expects(:new).returns(stat)
         File.expects(:exist?).with("agent_catalog_run_lockfile").returns(true)
         File.expects(:read).with("agent_catalog_run_lockfile").returns("1")
-        @manager.expects(:disabled?).returns(false)
         @manager.expects(:has_process_for_pid?).with("1").returns(true)
         @manager.applying?.should == true
       end
@@ -56,7 +49,6 @@ module MCollective::Util
         stat = OpenStruct.new(:size => 0)
         File.expects(:exist?).with("agent_catalog_run_lockfile").returns(true)
         File::Stat.expects(:new).returns(stat)
-        @manager.expects(:disabled?).returns(false)
         @manager.applying?.should == false
       end
 
@@ -65,13 +57,12 @@ module MCollective::Util
         File::Stat.expects(:new).returns(stat)
         File.expects(:exist?).with("agent_catalog_run_lockfile").returns(true)
         File.expects(:read).with("agent_catalog_run_lockfile").returns("1")
-        @manager.expects(:disabled?).returns(false)
         @manager.expects(:has_process_for_pid?).with("1").returns(false)
         @manager.applying?.should == false
       end
 
       it "should return false on any error" do
-        @manager.expects(:disabled?).raises("fail")
+        @manager.expects(:platform_applying?).raises("fail")
         MCollective::Log.expects(:warn)
         @manager.applying?.should == false
       end

--- a/util/puppet_agent_mgr.rb
+++ b/util/puppet_agent_mgr.rb
@@ -347,7 +347,6 @@ module MCollective
       # is the agent currently applying a catalog
       def applying?
         begin
-          return false if disabled?
           platform_applying?
         rescue NotImplementedError
           raise


### PR DESCRIPTION
When the agent is disabled it's assumed to be idle, but there could be a
period where if the agent was not idle when it was disabled it will
still be applying for a while.

This removes the short circuit and always checks the actual status