### PR TITLE
(MCOP-584) Consult windows path to puppet agent

### DIFF
--- a/agent/puppet.rb
+++ b/agent/puppet.rb
@@ -24,6 +24,8 @@ module MCollective
       def default_agent_command
         if File.exist?("/opt/puppetlabs/bin/puppet")
           "/opt/puppetlabs/bin/puppet agent"
+        elsif File.exist?("C:/Program Files/Puppet Labs/Puppet/bin/puppet.bat")
+          "C:/Program Files/Puppet Labs/Puppet/bin/puppet.bat agent"
         else
           "puppet agent"
         end

--- a/spec/agent/puppet_agent_spec.rb
+++ b/spec/agent/puppet_agent_spec.rb
@@ -46,6 +46,12 @@ describe "puppet agent" do
       expect(@agent.default_agent_command).to eq("/opt/puppetlabs/bin/puppet agent")
     end
 
+    it "should support windows AIO" do
+      File.expects(:exist?).with("/opt/puppetlabs/bin/puppet").returns(false)
+      File.expects(:exist?).with("C:/Program Files/Puppet Labs/Puppet/bin/puppet.bat").returns(true)
+      expect(@agent.default_agent_command).to eq("C:/Program Files/Puppet Labs/Puppet/bin/puppet.bat agent")
+    end
+
     it "should retain old default behaviour" do
       File.stubs(:exist?).returns(false)
       expect(@agent.default_agent_command).to eq("puppet agent")


### PR DESCRIPTION
When trying to find the path to the puppet executable also check the
windows paths before relying on PATH