### PR TITLE
(MCOP-599) Do not use Fixnum, use Integer instead

### DIFF
--- a/util/puppet_agent_mgr.rb
+++ b/util/puppet_agent_mgr.rb
@@ -221,7 +221,7 @@ module MCollective
           raise("Invalid environment '%s' specified" % environment)
         end
 
-        if splaylimit && !splaylimit.is_a?(Fixnum)
+        if splaylimit && !splaylimit.is_a?(Integer)
           raise("Invalid splaylimit '%s' specified" % splaylimit)
         end
 


### PR DESCRIPTION
Ruby 2.4 deprecated Fixnum and Bignum, Integer should now be used